### PR TITLE
Add product list adapter, simplify shopping_list_item

### DIFF
--- a/app/src/main/java/kres/realtimeshoppinglist/util/ProductListAdapter.java
+++ b/app/src/main/java/kres/realtimeshoppinglist/util/ProductListAdapter.java
@@ -1,0 +1,61 @@
+package kres.realtimeshoppinglist.util;
+
+import android.content.Context;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.widget.CheckBox;
+import android.widget.LinearLayout;
+import android.widget.RelativeLayout;
+import android.widget.TextView;
+
+import kres.realtimeshoppinglist.R;
+import kres.realtimeshoppinglist.model.Product;
+
+public class ProductListAdapter {
+
+    private LinearLayout productListLayout;
+    private LayoutInflater inflater;
+
+    public ProductListAdapter(LinearLayout productListLayout, Context context) {
+        this.productListLayout = productListLayout;
+        this.inflater = LayoutInflater.from(context);
+    }
+
+    public void removeItem(int index) {
+        productListLayout.removeViewAt(index);
+    }
+
+    public void moveItem(int oldIndex, int newIndex) {
+        Log.d("MOVING_ITEM", "From: " + oldIndex + " To: " + newIndex);
+        if (oldIndex == newIndex) {
+            return;
+        }
+
+        LinearLayout item = (LinearLayout) productListLayout.getChildAt(oldIndex);
+        productListLayout.removeViewAt(oldIndex);
+        productListLayout.addView(item, newIndex);
+    }
+
+    public void insertItem(int index, Product item) {
+        LinearLayout listItem = (LinearLayout) inflater.inflate(R.layout.shopping_list_item_layout, null, false);
+        CheckBox itemCheckBox = listItem.findViewById(R.id.list_item_check_box);
+
+        itemCheckBox.setText(String.format("%dx %s", item.getQuantity(), item.getName()));
+        itemCheckBox.setChecked(item.isBought());
+
+        if (index >= productListLayout.getChildCount()) {
+            productListLayout.addView(listItem);
+        } else {
+            productListLayout.addView(listItem, index);
+        }
+
+    }
+
+    public void updateItem(int index, Product newItem) {
+        LinearLayout listItem = (LinearLayout) productListLayout.getChildAt(index);
+        CheckBox itemCheckBox = listItem.findViewById(R.id.list_item_check_box);
+
+        itemCheckBox.setText(String.format("%dx %s", newItem.getQuantity(), newItem.getName()));
+        itemCheckBox.setChecked(newItem.isBought());
+    }
+}

--- a/app/src/main/res/layout/shopping_list_item_layout.xml
+++ b/app/src/main/res/layout/shopping_list_item_layout.xml
@@ -1,41 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="horizontal"
+    android:id="@+id/shopping_list_item_layout"
     android:padding="10dp">
 
-    <TextView
-        android:id="@+id/list_item_quantity_text_view"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentLeft="true"
-        android:layout_alignParentStart="true"
-        android:layout_centerVertical="true"
-        android:paddingRight="10dp"
-        android:paddingEnd="10dp"
-        android:text="@string/zero"
-        android:textSize="10pt" />
-
-    <TextView
-        android:id="@+id/list_item_name_text_view"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_toEndOf="@+id/list_item_quantity_text_view"
-        android:layout_toLeftOf="@+id/list_item_check_box"
-        android:layout_toRightOf="@+id/list_item_quantity_text_view"
-        android:layout_toStartOf="@+id/list_item_check_box"
-        android:layout_centerVertical="true"
-        android:text="@string/product_name"
-        android:textSize="10pt" />
-
-    <ImageView
+    <CheckBox
         android:id="@+id/list_item_check_box"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_alignParentEnd="true"
-        android:layout_alignParentRight="true"
-        android:layout_centerInParent="true"
-        app:srcCompat="@android:drawable/checkbox_off_background" />
-</RelativeLayout>
+        android:text="@string/quantity_product_name" />
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,4 +7,5 @@
     <string name="list_name">List Name</string>
     <string name="create">create</string>
     <string name="join">join</string>
+    <string name="quantity_product_name">Quantity - Product Name</string>
 </resources>


### PR DESCRIPTION
- Adds the `ProductListAdapater` class for dealing with the product list
- Replaces the entire `shopping_list_item_layout` contents with a `LinearLayout` containing a simple `CheckBox`

![](https://media.giphy.com/media/l0IylOPCNkiqOgMyA/giphy.gif)