### PR TITLE
Fix persistence bug

### DIFF
--- a/app/src/main/java/kres/realtimeshoppinglist/activities/ListSelectActivity.java
+++ b/app/src/main/java/kres/realtimeshoppinglist/activities/ListSelectActivity.java
@@ -37,6 +37,7 @@ public class ListSelectActivity extends AppCompatActivity implements ShoppingLis
         Set<String> knownIDs = persistenceManager.retrieveKnownIDs();
 
         for (final String id : knownIDs) {
+            Log.d("PERSISTENCE_MANAGER", "Found ID: " + id);
             ShoppingListManager.getShoppingList(id, new ListExistsListener() {
                 @Override
                 public void onListFound(ShoppingList list) {

--- a/app/src/main/java/kres/realtimeshoppinglist/dialog/remove/DeleteListDialog.java
+++ b/app/src/main/java/kres/realtimeshoppinglist/dialog/remove/DeleteListDialog.java
@@ -6,6 +6,7 @@ import android.content.DialogInterface;
 
 import kres.realtimeshoppinglist.firebase.shoppingList.ShoppingListAdapter;
 import kres.realtimeshoppinglist.firebase.shoppingList.ShoppingListManager;
+import kres.realtimeshoppinglist.persistence.PersistenceManager;
 
 public class DeleteListDialog {
 
@@ -36,6 +37,7 @@ public class DeleteListDialog {
             public void onClick(DialogInterface dialogInterface, int i) {
                 ShoppingListManager.deleteList(listID);
                 adapter.deleteItem(listID);
+                PersistenceManager.getInstance(context).removeKnownID(listID);
             }
         });
 

--- a/app/src/main/java/kres/realtimeshoppinglist/persistence/PersistenceManager.java
+++ b/app/src/main/java/kres/realtimeshoppinglist/persistence/PersistenceManager.java
@@ -52,6 +52,7 @@ public class PersistenceManager {
     }
 
     public Set<String> retrieveKnownIDs() {
-        return sharedPreferences.getStringSet(KNOWN_LISTS_SHARED_PREFERENCES_KEY, new HashSet<String>());
+        // Turns out you need to copy the set you get back into a new HashSet, otherwise shit breaks
+        return new HashSet<>(sharedPreferences.getStringSet(KNOWN_LISTS_SHARED_PREFERENCES_KEY, new HashSet<String>()));
     }
 }

--- a/app/src/main/java/kres/realtimeshoppinglist/persistence/PersistenceManager.java
+++ b/app/src/main/java/kres/realtimeshoppinglist/persistence/PersistenceManager.java
@@ -36,6 +36,7 @@ public class PersistenceManager {
         editor.putStringSet(KNOWN_LISTS_SHARED_PREFERENCES_KEY, knownIDs);
 
         editor.apply();
+        editor.commit();
     }
 
     public void removeKnownID(String listID) {
@@ -47,6 +48,7 @@ public class PersistenceManager {
         editor.putStringSet(KNOWN_LISTS_SHARED_PREFERENCES_KEY, knownIDs);
 
         editor.apply();
+        editor.commit();
     }
 
     public Set<String> retrieveKnownIDs() {

--- a/app/src/main/java/kres/realtimeshoppinglist/persistence/PersistenceManager.java
+++ b/app/src/main/java/kres/realtimeshoppinglist/persistence/PersistenceManager.java
@@ -9,14 +9,14 @@ import java.util.Set;
 
 public class PersistenceManager {
 
-    private static final String ID_PREFS = "host_id_prefs";
+    private static final String ID_PREFS = "shopping_list_id_prefs";
     private static final String KNOWN_LISTS_SHARED_PREFERENCES_KEY = "KNOWN_LISTS";
     private static PersistenceManager instance;
 
     private SharedPreferences sharedPreferences;
 
     private PersistenceManager(Context context) {
-        sharedPreferences = context.getSharedPreferences(PersistenceManager.ID_PREFS, 0);
+        sharedPreferences = context.getSharedPreferences(PersistenceManager.ID_PREFS, Context.MODE_PRIVATE);
     }
 
     public static PersistenceManager getInstance(Context context) {

--- a/app/src/main/java/kres/realtimeshoppinglist/persistence/PersistenceManager.java
+++ b/app/src/main/java/kres/realtimeshoppinglist/persistence/PersistenceManager.java
@@ -2,6 +2,7 @@ package kres.realtimeshoppinglist.persistence;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.util.Log;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -27,6 +28,7 @@ public class PersistenceManager {
     }
 
     public void persistKnownID(String listID) {
+        Log.d("PERSISTENCE_MANAGER", "Persisting ID: " + listID);
         Set<String> knownIDs = retrieveKnownIDs();
         knownIDs.add(listID);
 
@@ -37,6 +39,7 @@ public class PersistenceManager {
     }
 
     public void removeKnownID(String listID) {
+        Log.d("PERSISTENCE_MANAGER", "Removing ID: " + listID);
         Set<String> knownIDs = retrieveKnownIDs();
         knownIDs.remove(listID);
 


### PR DESCRIPTION
Turns out when you retrieve a `Set<String>` from `sharedPreferences`, that set is by _reference_ to the real thing stored in `sharedPreferences`, and shit gets super weird if you try edit that set by reference. So the solution is to make a _copy_ of the returned set before you do anything with it.

![](https://media.giphy.com/media/acCicUvhTCz2o/giphy.gif)