### PR TITLE
Update firebase to 16.0.0 and 16.0.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,8 +25,8 @@ dependencies {
     implementation 'com.android.support:design:27.1.1'
 
     // Firebase
-    implementation 'com.google.firebase:firebase-core:15.0.0'
-    implementation 'com.google.firebase:firebase-database:15.0.0'
+    implementation 'com.google.firebase:firebase-core:16.0.0'
+    implementation 'com.google.firebase:firebase-database:16.0.1'
 
     // Gson
     implementation 'com.google.code.gson:gson:2.8.2'


### PR DESCRIPTION
Fixes #70 

- Update `firebase-core` to `16.0.0` (latest)
- Update `firebase-database` to `16.0.1` (latest)

![](https://media.giphy.com/media/ha4w8wZC2jZBe/giphy.gif)